### PR TITLE
Build Linux release binaries on platform with glibc-2.27

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             - mac-x86-64
           include:
             - name: linux-x86-64-gnu
-              os: ubuntu-latest
+              os: ubuntu-18.04
               target: x86_64-unknown-linux-gnu
             - name: mac-x86-64
               os: macos-10.15


### PR DESCRIPTION
This lowers the dependency on glibc so it can be used on more platforms.

Closes #12.