### PR TITLE
Bump macos release pipeline to macos-11

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,7 +21,7 @@ jobs:
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
           - name: mac-x86-64
-            os: macos-latest
+            os: macos-11
             target: x86_64-apple-darwin
 
     name: Binaries for ${{ matrix.name }}


### PR DESCRIPTION
The `macos-10.15` runner is going away, see https://github.com/actions/virtual-environments/issues/5583.