### PR TITLE
Fix vs code extension build warning

### DIFF
--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -1,0 +1,11 @@
+*
+**
+
+!node_modules/got/dist/
+!out/extension.js
+!package.json
+!snippets/*
+!syntaxes/*
+!LICENSE
+!README.md
+!language-configuration.json


### PR DESCRIPTION
```
$ file zeek-language-server.vsix 
zeek-language-server.vsix: Zip archive data, at least v2.0 to extract, compression method=deflate
```
`yarn vsix` actually makes all files in the current directory into a zip package. If we don't have `.vscodeignore`, we will package many useless files (e.g. node_modules), which will affect the extension file size and performance.

We can also use `webpack` or `esbuild` to implement bundling[^Bundling], but there is only one `extension.ts` file in src,  so I don't think it's necessary.

[^Bundling]:Bundling is the process of combining multiple small source files into a single file.
