### PR TITLE
Remove the schema in language configuration

### DIFF
--- a/vscode/language-configuration.json
+++ b/vscode/language-configuration.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "comments": {
     "lineComment": "#"
   },


### PR DESCRIPTION
Language configuration is not a `tmLanguage` json.

<img width="731" alt="image" src="https://user-images.githubusercontent.com/30434507/191009058-d32ad6bc-6bb9-49b3-8c5f-d0dd2ad2cc69.png">
