### PR TITLE
Add an option to allows injecting PATH

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -49,6 +49,11 @@
     "configuration": {
       "type": "object",
       "properties": {
+        "zeekLanguageServer.zeekPath": {
+          "type": "string",
+          "default": "",
+          "description": "Full path to the zeek executable. If unset we will attempt to look it up in PATH."
+        },
         "zeekLanguageServer.path": {
           "type": "string",
           "default": "",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -49,7 +49,7 @@
     "configuration": {
       "type": "object",
       "properties": {
-        "zeekLanguageServer.zeekPath": {
+        "zeekLanguageServer.zeekBinaryDirectory": {
           "type": "string",
           "default": "",
           "description": "Full path to the zeek executable. If unset we will attempt to look it up in PATH."

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -52,7 +52,7 @@
         "zeekLanguageServer.zeekBinaryDirectory": {
           "type": "string",
           "default": "",
-          "description": "Full path to the zeek executable. If unset we will attempt to look it up in PATH."
+          "description": "Directory containing Zeek executables. If unset we will attempt to find them in PATH."
         },
         "zeekLanguageServer.path": {
           "type": "string",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -269,7 +269,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   const env = {
     PATH: workspace
       .getConfiguration("zeekLanguageServer")
-      .get<string>("zeekPath"),
+      .get<string>("zeekBinaryDirectory"),
   };
   if (env.PATH) {
     serverExecutable.options = { env };

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -266,6 +266,15 @@ export async function activate(context: ExtensionContext): Promise<void> {
     command: await server.getPath(),
   };
 
+  const env = {
+    PATH: workspace
+      .getConfiguration("zeekLanguageServer")
+      .get<string>("zeekPath"),
+  };
+  if (env.PATH) {
+    serverExecutable.options = { env };
+  }
+
   const serverOptions: ServerOptions = {
     run: serverExecutable,
     debug: serverExecutable,


### PR DESCRIPTION
Closes #34 

There is another way to implement it: let lsp support a argument to set the path of `zeek` and `zeek-config`.

@bbannier What's your opinion?