### PR TITLE
Add build and debug config for VS Code

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,4 @@
+# MD033/no-inline-html - Inline HTML
+MD033:
+  # Allowed elements
+  allowed_elements: ["kbd"]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  // See http://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": [
+    "vadimcn.vscode-lldb",
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "serayuzgur.crates"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,46 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+
+  // NOTE: --disable-extensions
+  // Disable all installed extensions to increase performance of the debug instance
+  // and prevent potential conflicts with other installed extensions.
+
+  "version": "0.2.0",
+  "configurations": [
+    {
+      // Used for testing the extension with a local build of the LSP server (in `target/debug`).
+      "name": "Run Extension (Debug Build)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--disable-extensions",
+        "--extensionDevelopmentPath=${workspaceFolder}/vscode/"
+      ],
+      "outFiles": ["${workspaceFolder}/vscode/out/**/*.js"],
+      "preLaunchTask": "Build Server and Extension",
+      "skipFiles": ["<node_internals>/**/*.js"],
+      "env": {
+        "__ZEEK_LSP_SERVER_DEBUG": "${workspaceFolder}/target/debug/zeek-language-server"
+      }
+    },
+    {
+      // Used to attach LLDB to a running LSP server.
+      // Require the CodeLLDB Extension.
+      // NOTE: Might require root permissions. For this run:
+      //
+      // `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`
+      //
+      // Don't forget to set `debug = 2` in `Cargo.toml` before building the server
+
+      "name": "Attach To Server",
+      "type": "lldb",
+      "request": "attach",
+      "program": "${workspaceFolder}/target/debug/zeek-language-server",
+      "pid": "${command:pickMyProcess}",
+      "sourceLanguages": ["rust"]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,6 @@
     },
     {
       // Used to attach LLDB to a running LSP server.
-      // Require the CodeLLDB Extension.
       // NOTE: Might require root permissions. For this run:
       //
       // `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,60 @@
+// See https://go.microsoft.com/fwlink/?LinkId=733558
+// for the documentation about the tasks.json format
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Install Extension Dependencies",
+      "group": "build",
+      "type": "npm",
+      "script": "install",
+      "path": "vscode/",
+      "problemMatcher": {
+        "base": "$tsc",
+        "fileLocation": ["relative", "${workspaceFolder}/vscode/"]
+      }
+    },
+    {
+      "label": "Build Extension in Background",
+      "dependsOn": ["Install Extension Dependencies"],
+      "group": "build",
+      "type": "npm",
+      "script": "watch",
+      "path": "vscode/",
+      "problemMatcher": {
+        "base": "$tsc-watch",
+        "fileLocation": ["relative", "${workspaceFolder}/vscode/"]
+      },
+      "isBackground": true
+    },
+    {
+      "label": "Build Extension",
+      "dependsOn": ["Install Extension Dependencies"],
+      "group": "build",
+      "type": "npm",
+      "script": "build",
+      "path": "vscode/",
+      "problemMatcher": {
+        "base": "$tsc",
+        "fileLocation": ["relative", "${workspaceFolder}/vscode/"]
+      }
+    },
+    {
+      "label": "Build Server",
+      "group": "build",
+      "type": "shell",
+      "command": "cargo build --package zeek-language-server",
+      "problemMatcher": "$rustc",
+      "options": {
+        "env": {
+          "PATH": "${env:HOME}/.cargo/bin:${env:PATH}"
+        }
+      }
+    },
+    {
+      "label": "Build Server and Extension",
+      "dependsOn": ["Build Server", "Build Extension"],
+      "problemMatcher": "$rustc"
+    }
+  ]
+}

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,84 @@
+# Debugging VSCode plugin and the language server
+
+## Prerequisites
+
+- You can successfully build this project from source.
+- Install [LLDB](https://lldb.llvm.org/) and the [LLDB Extension](https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb).
+- Open the root folder in VSCode. Press <kbd>Ctrl+Shift+D</kbd> and here you can
+access the preconfigured debug setups.
+
+## Common knowledge
+
+- All debug configurations open a new `[Extension Development Host]` VSCode
+instance where **only** the [Zeek](https://marketplace.visualstudio.com/items?itemName=bbannier.zeek-language-server)
+extension being debugged is enabled.
+- To activate the extension you need to open any Zeek script file (`.zeek/.bro`)
+in `[Extension Development Host]`.
+
+## Debug TypeScript VSCode extension
+
+- `Run Extension (Debug Build)` - runs extension with the locally built
+LSP server (`target/debug/zeek-language-server`).
+
+TypeScript debugging is configured to watch your source edits and recompile.
+To apply changes to an already running debug process,
+press <kbd>Ctrl+Shift+P</kbd> and run the following command in your
+`[Extension Development Host]`
+
+```shell
+> Developer: Reload Window
+```
+
+## Debug LSP server
+
+- When attaching a debugger to an already running `zeek-language-server`
+server on Linux you might need to enable `ptrace` for unrelated processes by running:
+
+  ```shell
+  echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope
+  ```
+
+- By default, the LSP server is built without debug information. To enable it,
+you'll need to change `Cargo.toml`:
+
+  ```toml
+    [profile.dev]
+    debug = 2
+  ```
+
+- Select `Run Extension (Debug Build)` to run your locally built `target/debug/zeek-language-server`.
+
+- In the original VSCode window once again select the `Attach To Server` debug configuration.
+
+- A list of running processes should appear. Select the `zeek-language-server`
+from this repo.
+
+- Navigate to `src/lsp.rs` and add a breakpoint to the `hover` function.
+
+- Go back to the `[Extension Development Host]` instance and hover over a Zeek
+variable and your breakpoint should hit.
+
+## Troubleshooting
+
+### Can't find the `zeek-language-server` process
+
+It could be a case of just jumping the gun.
+
+The `zeek-language-server` is only started once the `onLanguage:zeek` activation.
+
+Make sure you open a Zeek script file in the `[Extension Development Host]`
+and try again.
+
+### Can't connect to `zeek-language-server`
+
+Make sure you have run `echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`.
+
+By default this should reset back to 1 every time you log in.
+
+### Breakpoints are never being hit
+
+Check your version of `lldb`. If it's version 6 and lower,
+use the `classic` adapter type. It's `lldb.adapterType` in settings file.
+
+If you're running `lldb` version 7,
+change the lldb adapter type to `bundled` or `native`.

--- a/README.md
+++ b/README.md
@@ -54,3 +54,8 @@ cargo install --git https://github.com/bbannier/zeek-language-server.git
 This installs a binary `zeek-language-server` which provides the full server.
 
 [rustup]: https://rustup.rs
+
+## Debugging
+
+See [these instructions](./DEBUGGING.md) for VS Code setup and the list of
+features (some of which are VS Code specific).

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -264,10 +264,10 @@ export async function activate(context: ExtensionContext): Promise<void> {
   await checkDependencies();
 
   // Start the server.
-  const server = new ZeekLanguageServer(context);
-
   const serverExecutable: Executable = {
-    command: await server.getPath(),
+    command:
+      process.env.__ZEEK_LSP_SERVER_DEBUG ??
+      (await new ZeekLanguageServer(context).getPath()),
   };
 
   const env = {


### PR DESCRIPTION
# Introduction
Mainly to simplify debugging lsp and extension in VS Code. And it will help new contributors to join us.

# In-progress tasks
- [x] Add debugging documentation