### PR TITLE
Revert "Switch Linux binaries to musl"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       matrix:
         name:
-          - linux-x86-64-musl
+          - linux-x86-64-gnu
           - mac-x86-64
         include:
-          - name: linux-x86-64-musl
+          - name: linux-x86-64-gnu
             os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            target: x86_64-unknown-linux-gnu
           - name: mac-x86-64
             os: macos-latest
             target: x86_64-apple-darwin
@@ -34,25 +34,17 @@ jobs:
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
-      - name: Install musl-tools
-        if: contains(matrix.name, 'linux')
-        run: |
-          sudo apt-get update; \
-          sudo apt-get install -y musl-tools
-
       - name: Install tree-sitter-cli
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
         with:
           command: install
           args: tree-sitter-cli
-
       - name: Install Zeek
         run: |
           if [[ ${{ matrix.name }} == *linux* ]]; then \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
           name:
-            - linux-x86-64-musl
+            - linux-x86-64-gnu
             - mac-x86-64
           include:
-            - name: linux-x86-64-musl
-              os: ubuntu-latest
-              target: x86_64-unknown-linux-musl
+            - name: linux-x86-64-gnu
+              os: ubuntu-18.04
+              target: x86_64-unknown-linux-gnu
             - name: mac-x86-64
               os: macos-11
               target: x86_64-apple-darwin
@@ -32,18 +32,11 @@ jobs:
       - uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af
         with:
           toolchain: stable
-          target: ${{ matrix.target }}
           profile: minimal
           override: true
       - uses: Swatinem/rust-cache@v1
         with:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: Install musl-tools
-        if: contains(matrix.name, 'linux')
-        run: |
-          sudo apt-get update; \
-          sudo apt-get install -y musl-tools
 
       - name: Install tree-sitter-cli
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -30,7 +30,7 @@ const BASE_URL =
   "https://github.com/bbannier/zeek-language-server/releases/download";
 
 const PLATFORMS = {
-  linux: "x86_64-unknown-linux-musl",
+  linux: "x86_64-unknown-linux-gnu",
   darwin: "x86_64-apple-darwin",
 };
 


### PR DESCRIPTION
This reverts commit 33d16b0d909e1fb80091fc6ecfbf97943b51fcfa.

It seems that when building with musl e.g., the server's initial scan of the system directories takes orders of magnitude longer. Reverting back to non-musl Linux binaries for now.