### PR TITLE
Do not attempt to start server on unsupported platforms

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -261,6 +261,13 @@ async function checkDependencies(): Promise<void> {
 }
 
 export async function activate(context: ExtensionContext): Promise<void> {
+  // Do not attempt to start server on unsupported platforms.
+  const platform = process.platform;
+  if (!PLATFORMS[platform]) {
+    log.info(`IntelliSense is unsupported on platform ${platform}`);
+    return;
+  }
+
   // Register commands.
   context.subscriptions.push(commands.registerCommand("zeek.tryZeek", tryZeek));
 


### PR DESCRIPTION
This extension now contains more than just support for running the server, so it makes sense to use it on other platforms as well. On such platforms we would still have emitted an error message about being unable to download the server, and also would have performed a check for `zeek-format` which is useless without the server

With this patch we now skip the server initialization on such platforms and emit a simple information message.