### PR TITLE
Pin Github Linux job to `ubuntu-22.04`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
@@ -91,7 +91,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: pre-commit-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Install tree-sitter-cli

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
           - mac-x86-64
         include:
           - name: linux-x86-64-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
           - name: mac-x86-64
             os: macos-latest
@@ -49,8 +49,8 @@ jobs:
       - name: Install Zeek
         run: |
           if [[ ${{ matrix.name }} == *linux* ]]; then \
-            echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list; \
-            curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null; \
+            echo 'deb http://download.opensuse.org/repositories/security:/zeek/xUbuntu_22.04/ /' | sudo tee /etc/apt/sources.list.d/security:zeek.list; \
+            curl -fsSL https://download.opensuse.org/repositories/security:zeek/xUbuntu_22.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/security_zeek.gpg > /dev/null; \
             sudo apt-get update; \
             sudo apt-get install -y zeek; \
             sudo echo /opt/zeek/bin >> ${GITHUB_PATH}; \
@@ -81,7 +81,7 @@ jobs:
 
   pre-commit:
     name: Run pre-commit hooks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             - mac-x86-64
           include:
             - name: linux-x86-64-gnu
-              os: ubuntu-latest
+              os: ubuntu-22.04
               target: x86_64-unknown-linux-gnu
             - name: mac-x86-64
               os: macos-11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
         with:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 


### PR DESCRIPTION
We previously ran on `ubuntu-latest`, but when installing packages assumed that referred to `ubuntu-20.04`. With this patch we now use a fixed version for Github Linux jobs with matching repo.