### PR TITLE
Make it possible to trigger field completion with partial field name

### DIFF
--- a/src/snapshots/zeek_language_server__lsp__test__completion_field_partial.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__completion_field_partial.snap
@@ -1,0 +1,40 @@
+---
+source: src/lsp.rs
+expression: "server.completion(CompletionParams { context: None, ..params.clone() }).await"
+---
+Ok(
+    Some(
+        Array(
+            [
+                CompletionItem {
+                    label: "abc",
+                    kind: Some(
+                        Field,
+                    ),
+                    detail: None,
+                    documentation: Some(
+                        MarkupContent(
+                            MarkupContent {
+                                kind: Markdown,
+                                value: "```zeek\n# In X\nabc: count;\n```",
+                            },
+                        ),
+                    ),
+                    deprecated: None,
+                    preselect: None,
+                    sort_text: None,
+                    filter_text: None,
+                    insert_text: None,
+                    insert_text_format: None,
+                    insert_text_mode: None,
+                    text_edit: None,
+                    additional_text_edits: None,
+                    command: None,
+                    commit_characters: None,
+                    data: None,
+                    tags: None,
+                },
+            ],
+        ),
+    ),
+)


### PR DESCRIPTION
We previously couldn't trigger field name completion with a partial field name, e.g., if there is a field `abc`, we could not trigger after `x$a`. This patch allows completion in the position as well.