### PR TITLE
Improve type inference for untyped variables

### DIFF
--- a/src/snapshots/zeek_language_server__ast__test__typ_var_decl-2.snap
+++ b/src/snapshots/zeek_language_server__ast__test__typ_var_decl-2.snap
@@ -1,0 +1,45 @@
+---
+source: src/ast.rs
+expression: db.typ(decl)
+---
+Some(
+    Decl {
+        module: None,
+        id: "b",
+        fqid: "A::b",
+        kind: Field,
+        is_export: None,
+        range: Range {
+            start: Position {
+                line: 5,
+                character: 16,
+            },
+            end: Position {
+                line: 5,
+                character: 17,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 5,
+                character: 16,
+            },
+            end: Position {
+                line: 5,
+                character: 17,
+            },
+        },
+        documentation: "```zeek\n# In A\nb: B;\n```",
+        uri: Url {
+            scheme: "file",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/x.zeek",
+            query: None,
+            fragment: None,
+        },
+    },
+)

--- a/src/snapshots/zeek_language_server__ast__test__typ_var_decl-3.snap
+++ b/src/snapshots/zeek_language_server__ast__test__typ_var_decl-3.snap
@@ -1,0 +1,45 @@
+---
+source: src/ast.rs
+expression: db.typ(decl)
+---
+Some(
+    Decl {
+        module: None,
+        id: "i",
+        fqid: "B::i",
+        kind: Field,
+        is_export: None,
+        range: Range {
+            start: Position {
+                line: 2,
+                character: 16,
+            },
+            end: Position {
+                line: 2,
+                character: 17,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 2,
+                character: 16,
+            },
+            end: Position {
+                line: 2,
+                character: 17,
+            },
+        },
+        documentation: "```zeek\n# In B\ni: count;\n```",
+        uri: Url {
+            scheme: "file",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/x.zeek",
+            query: None,
+            fragment: None,
+        },
+    },
+)

--- a/src/snapshots/zeek_language_server__ast__test__typ_var_decl-4.snap
+++ b/src/snapshots/zeek_language_server__ast__test__typ_var_decl-4.snap
@@ -1,0 +1,89 @@
+---
+source: src/ast.rs
+expression: db.typ(decl)
+---
+Some(
+    Decl {
+        module: None,
+        id: "B",
+        fqid: "B",
+        kind: Type(
+            [
+                Decl {
+                    module: None,
+                    id: "i",
+                    fqid: "B::i",
+                    kind: Field,
+                    is_export: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 16,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 17,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 16,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 17,
+                        },
+                    },
+                    documentation: "```zeek\n# In B\ni: count;\n```",
+                    uri: Url {
+                        scheme: "file",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: None,
+                        port: None,
+                        path: "/x.zeek",
+                        query: None,
+                        fragment: None,
+                    },
+                },
+            ],
+        ),
+        is_export: Some(
+            false,
+        ),
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 12,
+            },
+            end: Position {
+                line: 3,
+                character: 14,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 17,
+            },
+            end: Position {
+                line: 1,
+                character: 18,
+            },
+        },
+        documentation: "```zeek\ntype B: record {\n                i: count;\n            };\n```",
+        uri: Url {
+            scheme: "file",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/x.zeek",
+            query: None,
+            fragment: None,
+        },
+    },
+)

--- a/src/snapshots/zeek_language_server__ast__test__typ_var_decl.snap
+++ b/src/snapshots/zeek_language_server__ast__test__typ_var_decl.snap
@@ -1,0 +1,89 @@
+---
+source: src/ast.rs
+expression: db.typ(decl)
+---
+Some(
+    Decl {
+        module: None,
+        id: "B",
+        fqid: "B",
+        kind: Type(
+            [
+                Decl {
+                    module: None,
+                    id: "i",
+                    fqid: "B::i",
+                    kind: Field,
+                    is_export: None,
+                    range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 16,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 17,
+                        },
+                    },
+                    selection_range: Range {
+                        start: Position {
+                            line: 2,
+                            character: 16,
+                        },
+                        end: Position {
+                            line: 2,
+                            character: 17,
+                        },
+                    },
+                    documentation: "```zeek\n# In B\ni: count;\n```",
+                    uri: Url {
+                        scheme: "file",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: None,
+                        port: None,
+                        path: "/x.zeek",
+                        query: None,
+                        fragment: None,
+                    },
+                },
+            ],
+        ),
+        is_export: Some(
+            false,
+        ),
+        range: Range {
+            start: Position {
+                line: 1,
+                character: 12,
+            },
+            end: Position {
+                line: 3,
+                character: 14,
+            },
+        },
+        selection_range: Range {
+            start: Position {
+                line: 1,
+                character: 17,
+            },
+            end: Position {
+                line: 1,
+                character: 18,
+            },
+        },
+        documentation: "```zeek\ntype B: record {\n                i: count;\n            };\n```",
+        uri: Url {
+            scheme: "file",
+            cannot_be_a_base: false,
+            username: "",
+            password: None,
+            host: None,
+            port: None,
+            path: "/x.zeek",
+            query: None,
+            fragment: None,
+        },
+    },
+)


### PR DESCRIPTION
Previously we most of the time would not resolve the type of variables declared without an explicit type. This patch improves this situation.

Closes #66.