### PR TITLE
Fix chained completions

### DIFF
--- a/src/snapshots/zeek_language_server__complete__test__field_access_chained.snap
+++ b/src/snapshots/zeek_language_server__complete__test__field_access_chained.snap
@@ -1,0 +1,38 @@
+---
+source: src/complete.rs
+expression: "complete(&db.0,\n    CompletionParams {\n        text_document_position: TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri.as_ref().clone()),\n            Position::new(4, 16)),\n        work_done_progress_params: WorkDoneProgressParams::default(),\n        partial_result_params: PartialResultParams::default(),\n        context: None,\n    })"
+---
+Some(
+    Array(
+        [
+            CompletionItem {
+                label: "n",
+                kind: Some(
+                    Field,
+                ),
+                detail: None,
+                documentation: Some(
+                    MarkupContent(
+                        MarkupContent {
+                            kind: Markdown,
+                            value: "```zeek\n# In X\nn: count;\n```",
+                        },
+                    ),
+                ),
+                deprecated: None,
+                preselect: None,
+                sort_text: None,
+                filter_text: None,
+                insert_text: None,
+                insert_text_format: None,
+                insert_text_mode: None,
+                text_edit: None,
+                additional_text_edits: None,
+                command: None,
+                commit_characters: None,
+                data: None,
+                tags: None,
+            },
+        ],
+    ),
+)

--- a/src/snapshots/zeek_language_server__complete__test__field_access_chained_partial.snap
+++ b/src/snapshots/zeek_language_server__complete__test__field_access_chained_partial.snap
@@ -1,0 +1,38 @@
+---
+source: src/complete.rs
+expression: "complete(&db.0,\n    CompletionParams {\n        text_document_position: TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri.as_ref().clone()),\n            Position::new(4, 17)),\n        work_done_progress_params: WorkDoneProgressParams::default(),\n        partial_result_params: PartialResultParams::default(),\n        context: None,\n    })"
+---
+Some(
+    Array(
+        [
+            CompletionItem {
+                label: "abc",
+                kind: Some(
+                    Field,
+                ),
+                detail: None,
+                documentation: Some(
+                    MarkupContent(
+                        MarkupContent {
+                            kind: Markdown,
+                            value: "```zeek\n# In X\nabc: count;\n```",
+                        },
+                    ),
+                ),
+                deprecated: None,
+                preselect: None,
+                sort_text: None,
+                filter_text: None,
+                insert_text: None,
+                insert_text_format: None,
+                insert_text_mode: None,
+                text_edit: None,
+                additional_text_edits: None,
+                command: None,
+                commit_characters: None,
+                data: None,
+                tags: None,
+            },
+        ],
+    ),
+)


### PR DESCRIPTION
This got broken when adding support for completing partially existing identifiers.

Closes #65.