### PR TITLE
Install tree-sitter-cli in CI with npm instead of cargo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,10 +42,8 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Install tree-sitter-cli
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
-        with:
-          command: install
-          args: tree-sitter-cli
+        run: |
+          npm install -g tree-sitter-cli
       - name: Install Zeek
         run: |
           if [[ ${{ matrix.name }} == *linux* ]]; then \
@@ -95,9 +93,7 @@ jobs:
         with:
           key: pre-commit-cargo-${{ hashFiles('Cargo.lock') }}
       - name: Install tree-sitter-cli
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
-        with:
-          command: install
-          args: tree-sitter-cli
+        run: |
+          npm install -g tree-sitter-cli
       - uses: actions/setup-python@v2
       - uses: pre-commit/action@v2.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,8 @@ jobs:
           key: ${{ matrix.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Install tree-sitter-cli
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505
-        with:
-          command: install
-          args: tree-sitter-cli
+        run: |
+          npm install -g tree-sitter-cli
 
       - name: Build binaries
         uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505


### PR DESCRIPTION
This takes out a potentially lengthy compilation process in case npm has binaries for our platform.