### PR TITLE
Fix extension not working on VS Code < 1.67

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "got": "^12.1.2",
-        "vscode-languageclient": "^8.0.0",
+        "vscode-languageclient": "^7.0.0",
         "vscode-uri": "^3.0.3"
       },
       "devDependencies": {
@@ -3589,39 +3589,39 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.2.tgz",
-      "integrity": "sha512-RY7HwI/ydoC1Wwg4gJ3y6LpU9FJRZAUnTYMXthqhFXXu77ErDd/xkREpGuk4MyYkk4a+XDWAMqe0S3KkelYQEQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-6.0.0.tgz",
+      "integrity": "sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==",
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.2.tgz",
-      "integrity": "sha512-lHlthJtphG9gibGb/y72CKqQUxwPsMXijJVpHEC2bvbFqxmkj9LwQ3aGU9dwjBLqsX1S4KjShYppLvg1UJDF/Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-7.0.0.tgz",
+      "integrity": "sha512-P9AXdAPlsCgslpP9pRxYPqkNYV7Xq8300/aZDpO35j1fJm/ncize8iGswzYlcvFw5DQUx4eVk+KvfXdL0rehNg==",
       "dependencies": {
         "minimatch": "^3.0.4",
-        "semver": "^7.3.5",
-        "vscode-languageserver-protocol": "3.17.2"
+        "semver": "^7.3.4",
+        "vscode-languageserver-protocol": "3.16.0"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.52.0"
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.2.tgz",
-      "integrity": "sha512-8kYisQ3z/SQ2kyjlNeQxbkkTNmVFoQCqkmGrzLH6A9ecPlgTbp3wDTnUNqaUxYr4vlAcloxx8zwy7G5WdguYNg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.16.0.tgz",
+      "integrity": "sha512-sdeUoAawceQdgIfTI+sdcwkiK2KU+2cbEYA0agzM2uqaUy2UpnnGHtWTHVEtS0ES4zHU0eMFRGN+oQgDxlD66A==",
       "dependencies": {
-        "vscode-jsonrpc": "8.0.2",
-        "vscode-languageserver-types": "3.17.2"
+        "vscode-jsonrpc": "6.0.0",
+        "vscode-languageserver-types": "3.16.0"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz",
-      "integrity": "sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA=="
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
+      "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
     "node_modules/vscode-uri": {
       "version": "3.0.7",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -143,7 +143,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build-base -- --minify",
     "vsix": "vsce package -o zeek-language-server.vsix",
-    "build-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node",
+    "build-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node --target=node12",
     "build": "npm run build-base -- --sourcemap",
     "watch": "npm run build-base -- --sourcemap --watch",
     "lint": "prettier --check . && eslint --ext=ts .",
@@ -151,7 +151,7 @@
   },
   "dependencies": {
     "got": "^12.1.2",
-    "vscode-languageclient": "^8.0.0",
+    "vscode-languageclient": "^7.0.0",
     "vscode-uri": "^3.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION

- The version of vscode-languageclient is bound to the version of the VS code engine, so we must bump their versions at the same time, otherwise the lower version of vs code will not be able to activate the extension.
- VS Code v1.52 uses node12. but three-party libraries (e.g. got) may use features of higher version nodejs, which will cause missing modules when activating extensions. So we solve it by adding `--target node12`.


https://github.com/microsoft/vscode-languageserver-node/blob/20681d7632bb129def0c751be73cf76bd01f2f3a/client/package.json#L7-L9
https://github.com/microsoft/vscode-languageserver-node/blob/f1f8e1a28a3cd35d21b41966724ac405ca52ce26/client/package.json#L7-L9