### PR TITLE
Prefer to resolve IDs to declarations instead of definitions

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -75,7 +75,7 @@ impl Ord for Location {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Location {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         NodeLocation::from_range(self.uri.clone(), self.range).hash(state);
@@ -193,7 +193,7 @@ impl NodeLocation {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for NodeLocation {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.range.start.line.hash(state);
@@ -205,7 +205,7 @@ impl Hash for NodeLocation {
     }
 }
 
-#[allow(clippy::derive_hash_xor_eq)]
+#[allow(clippy::derived_hash_with_manual_eq)]
 impl Hash for Decl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.module.hash(state);

--- a/src/snapshots/zeek_language_server__lsp__test__goto_definition-2.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__goto_definition-2.snap
@@ -1,0 +1,33 @@
+---
+source: src/lsp.rs
+expression: "server.goto_declaration(super::GotoDefinitionParams {\n            text_document_position_params: TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri.as_ref().clone()),\n                Position::new(4, 8)),\n            partial_result_params: PartialResultParams::default(),\n            work_done_progress_params: WorkDoneProgressParams::default(),\n        }).await"
+---
+Ok(
+    Some(
+        Scalar(
+            Location {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "/events.bif.zeek",
+                    query: None,
+                    fragment: None,
+                },
+                range: Range {
+                    start: Position {
+                        line: 0,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 0,
+                        character: 26,
+                    },
+                },
+            },
+        ),
+    ),
+)

--- a/src/snapshots/zeek_language_server__lsp__test__goto_definition.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__goto_definition.snap
@@ -1,0 +1,33 @@
+---
+source: src/lsp.rs
+expression: "server.goto_declaration(super::GotoDefinitionParams {\n            text_document_position_params: TextDocumentPositionParams::new(TextDocumentIdentifier::new(uri.as_ref().clone()),\n                Position::new(3, 8)),\n            partial_result_params: PartialResultParams::default(),\n            work_done_progress_params: WorkDoneProgressParams::default(),\n        }).await"
+---
+Ok(
+    Some(
+        Scalar(
+            Location {
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "/x.zeek",
+                    query: None,
+                    fragment: None,
+                },
+                range: Range {
+                    start: Position {
+                        line: 2,
+                        character: 0,
+                    },
+                    end: Position {
+                        line: 2,
+                        character: 29,
+                    },
+                },
+            },
+        ),
+    ),
+)

--- a/src/snapshots/zeek_language_server__lsp__test__hover_definition-2.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__hover_definition-2.snap
@@ -1,0 +1,35 @@
+---
+source: src/lsp.rs
+expression: "server.hover(HoverParams {\n            text_document_position_params: TextDocumentPositionParams {\n                text_document: TextDocumentIdentifier::new(uri.as_ref().clone()),\n                position: Position::new(10, 15),\n            },\n            work_done_progress_params: WorkDoneProgressParams::default(),\n        }).await"
+---
+Ok(
+    Some(
+        Hover {
+            contents: Array(
+                [
+                    String(
+                        "### event `zeek_init`",
+                    ),
+                    String(
+                        "Type: `event()`",
+                    ),
+                    String(
+                        "Declaration.\n```zeek\nglobal zeek_init: event();\n```",
+                    ),
+                ],
+            ),
+            range: Some(
+                Range {
+                    start: Position {
+                        line: 10,
+                        character: 14,
+                    },
+                    end: Position {
+                        line: 10,
+                        character: 23,
+                    },
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/zeek_language_server__lsp__test__hover_definition-3.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__hover_definition-3.snap
@@ -1,0 +1,32 @@
+---
+source: src/lsp.rs
+expression: "server.hover(HoverParams {\n            text_document_position_params: TextDocumentPositionParams {\n                text_document: TextDocumentIdentifier::new(uri.as_ref().clone()),\n                position: Position::new(13, 15),\n            },\n            work_done_progress_params: WorkDoneProgressParams::default(),\n        }).await"
+---
+Ok(
+    Some(
+        Hover {
+            contents: Array(
+                [
+                    String(
+                        "### event `bar`",
+                    ),
+                    String(
+                        "Declaration & definition.\n```zeek\nevent bar() {}\n```",
+                    ),
+                ],
+            ),
+            range: Some(
+                Range {
+                    start: Position {
+                        line: 13,
+                        character: 14,
+                    },
+                    end: Position {
+                        line: 13,
+                        character: 17,
+                    },
+                },
+            ),
+        },
+    ),
+)

--- a/src/snapshots/zeek_language_server__lsp__test__hover_definition.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__hover_definition.snap
@@ -1,0 +1,35 @@
+---
+source: src/lsp.rs
+expression: "server.hover(HoverParams {\n            text_document_position_params: TextDocumentPositionParams {\n                text_document: TextDocumentIdentifier::new(uri.as_ref().clone()),\n                position: Position::new(7, 15),\n            },\n            work_done_progress_params: WorkDoneProgressParams::default(),\n        }).await"
+---
+Ok(
+    Some(
+        Hover {
+            contents: Array(
+                [
+                    String(
+                        "### event `foo`",
+                    ),
+                    String(
+                        "Type: `event()`",
+                    ),
+                    String(
+                        "Declaration.\n```zeek\nglobal foo: event();\n```",
+                    ),
+                ],
+            ),
+            range: Some(
+                Range {
+                    start: Position {
+                        line: 7,
+                        character: 14,
+                    },
+                    end: Position {
+                        line: 7,
+                        character: 17,
+                    },
+                },
+            ),
+        },
+    ),
+)


### PR DESCRIPTION
For constructs which can have separate declarations and definitions (events, functions, hooks) when resolving IDs we previously would always return the last instance. Most of the time this meant a definition and not the declaration which at least in the case of Zeek base scripts has the documentation.

We now prefer to return the definition instead. This fixes gotodef for e.g., event handler implementations. We also now show to docstring from the declaration which most of the time is more useful (user scripts contain many implementations of events declared and documented elsewhere).