### PR TITLE
Fix suppression of param inlay hint

### DIFF
--- a/src/snapshots/zeek_language_server__lsp__test__inlay_hint_function_params.snap
+++ b/src/snapshots/zeek_language_server__lsp__test__inlay_hint_function_params.snap
@@ -1,6 +1,7 @@
 ---
 source: src/lsp.rs
 expression: "server.inlay_hint(InlayHintParams\n{\n    text_document: TextDocumentIdentifier::new((*uri).clone()), range:\n    Range::new(Position::new(0, 0), Position::new(u32::MAX, 0)),\n    work_done_progress_params: WorkDoneProgressParams::default(),\n}).await"
+snapshot_kind: text
 ---
 Ok(
     Some(
@@ -87,6 +88,32 @@ Ok(
                 position: Position {
                     line: 5,
                     character: 17,
+                },
+                label: String(
+                    "x:",
+                ),
+                kind: Some(
+                    Parameter,
+                ),
+                text_edits: None,
+                tooltip: Some(
+                    MarkupContent(
+                        MarkupContent {
+                            kind: Markdown,
+                            value: "```zeek\nx: count\n```",
+                        },
+                    ),
+                ),
+                padding_left: None,
+                padding_right: Some(
+                    true,
+                ),
+                data: None,
+            },
+            InlayHint {
+                position: Position {
+                    line: 8,
+                    character: 10,
                 },
                 label: String(
                     "x:",


### PR DESCRIPTION
We would previously suppress param inlay hints for args like `n - 1` if the parameter was named `n`. Now actually require the exact same spelling.