### PR TITLE
Simplify query

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1043,17 +1043,16 @@ pub fn fn_param_decls(node: Node, uri: Arc<Url>, source: &[u8]) -> FxHashSet<Dec
 }
 
 /// Extract for loop parameters on the given node.
+#[instrument]
 fn loop_param_decls(node: Node, uri: &Arc<Url>, source: &[u8]) -> FxHashSet<Decl> {
     static QUERY: LazyLock<tree_sitter::Query> = LazyLock::new(|| {
         tree_sitter::Query::new(
             &language_zeek(),
             r#"
         (for
-          "("
-          .
           [
-              ("[" (id)@key . ("," (id)@key)* . "]". (id)?@value)
-              ((id)@idx . ("," . (id)@idx)*)
+              ("[" . ( (id)@key . ","? )* . "]" . (id)?@value)
+              ( (id)@idx . ","? )*
           ]
           .
           "in"


### PR DESCRIPTION
This query had a lot of states which can cause constructing it to be _very_ expensive (in my local profiling about 30% of total startup time). I believe this is due to
https://github.com/tree-sitter/tree-sitter/issues/973 which has been sitting for a while.

As a workaround strip the query down to what we really need. As we remove more and more stuff the danger is that we might end up matching unrelated code, but what is here now seems to be sufficient.