### PR TITLE
Do not wrap lines in zeekygen docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,7 +2638,7 @@ dependencies = [
 
 [[package]]
 name = "zeek-language-server"
-version = "0.64.4"
+version = "0.64.5"
 dependencies = [
  "clap",
  "conv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeek-language-server"
-version = "0.64.4"
+version = "0.64.5"
 edition = "2021"
 license = "GPL-3.0-only"
 repository = "https://github.com/bbannier/zeek-language-server"

--- a/src/query.rs
+++ b/src/query.rs
@@ -1406,6 +1406,7 @@ mod test {
 
     use crate::{lsp::TestDatabase, parse::Parse, query::Node, Files};
     use insta::assert_debug_snapshot;
+    use itertools::Itertools;
     use tower_lsp::lsp_types::{Position, Url};
 
     use super::Query;
@@ -1472,7 +1473,7 @@ mod test {
 
         // Test decls reachable from the root node. This is used e.g., to figure out what decls are
         // available in a module. This should not contain e.g., function-scope decls.
-        let root_decls = decls_(tree.root_node());
+        let root_decls: Vec<_> = decls_(tree.root_node()).into_iter().sorted().collect();
         assert_eq!(7, root_decls.len());
         assert_debug_snapshot!(root_decls);
 

--- a/src/snapshots/zeek_language_server__query__test__decls_.snap
+++ b/src/snapshots/zeek_language_server__query__test__decls_.snap
@@ -1,8 +1,102 @@
 ---
 source: src/query.rs
 expression: root_decls
+snapshot_kind: text
 ---
-{
+[
+    Decl {
+        module: String(
+            "bar",
+        ),
+        id: "Y",
+        fqid: "Y",
+        kind: RedefRecord(
+            [
+                Decl {
+                    module: None,
+                    id: "y2",
+                    fqid: "bar::Y::y2",
+                    kind: Field,
+                    is_export: None,
+                    loc: Some(
+                        Location {
+                            range: Range {
+                                start: Position {
+                                    line: 24,
+                                    character: 18,
+                                },
+                                end: Position {
+                                    line: 24,
+                                    character: 20,
+                                },
+                            },
+                            selection_range: Range {
+                                start: Position {
+                                    line: 24,
+                                    character: 18,
+                                },
+                                end: Position {
+                                    line: 24,
+                                    character: 20,
+                                },
+                            },
+                            uri: Url {
+                                scheme: "file",
+                                cannot_be_a_base: false,
+                                username: "",
+                                password: None,
+                                host: None,
+                                port: None,
+                                path: "/foo/bar.zeek",
+                                query: None,
+                                fragment: None,
+                            },
+                        },
+                    ),
+                    documentation: "A new field.\n* * *\n```zeek\n# In bar::Y\ny2: count &optional;\n```",
+                },
+            ],
+        ),
+        is_export: Some(
+            false,
+        ),
+        loc: Some(
+            Location {
+                range: Range {
+                    start: Position {
+                        line: 22,
+                        character: 14,
+                    },
+                    end: Position {
+                        line: 25,
+                        character: 16,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 22,
+                        character: 27,
+                    },
+                    end: Position {
+                        line: 22,
+                        character: 28,
+                    },
+                },
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "/foo/bar.zeek",
+                    query: None,
+                    fragment: None,
+                },
+            },
+        ),
+        documentation: "```zeek\nredef record Y += {\n                  ## A new field.\n                  y2: count &optional;\n              };\n```",
+    },
     Decl {
         module: String(
             "bar",
@@ -100,58 +194,6 @@ expression: root_decls
             },
         ),
         documentation: "```zeek\nglobal fun: function(x: count): string;\n```",
-    },
-    Decl {
-        module: String(
-            "bar",
-        ),
-        id: "zeek_init",
-        fqid: "bar::zeek_init",
-        kind: EventDef(
-            Signature {
-                result: None,
-                args: [],
-            },
-        ),
-        is_export: Some(
-            false,
-        ),
-        loc: Some(
-            Location {
-                range: Range {
-                    start: Position {
-                        line: 15,
-                        character: 14,
-                    },
-                    end: Position {
-                        line: 17,
-                        character: 15,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: 15,
-                        character: 20,
-                    },
-                    end: Position {
-                        line: 15,
-                        character: 29,
-                    },
-                },
-                uri: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/foo/bar.zeek",
-                    query: None,
-                    fragment: None,
-                },
-            },
-        ),
-        documentation: "```zeek\nevent zeek_init() { local x=1;\n                  # Comment.\n              }\n```",
     },
     Decl {
         module: String(
@@ -255,54 +297,13 @@ expression: root_decls
         module: String(
             "bar",
         ),
-        id: "Y",
-        fqid: "Y",
-        kind: RedefRecord(
-            [
-                Decl {
-                    module: None,
-                    id: "y2",
-                    fqid: "bar::Y::y2",
-                    kind: Field,
-                    is_export: None,
-                    loc: Some(
-                        Location {
-                            range: Range {
-                                start: Position {
-                                    line: 24,
-                                    character: 18,
-                                },
-                                end: Position {
-                                    line: 24,
-                                    character: 20,
-                                },
-                            },
-                            selection_range: Range {
-                                start: Position {
-                                    line: 24,
-                                    character: 18,
-                                },
-                                end: Position {
-                                    line: 24,
-                                    character: 20,
-                                },
-                            },
-                            uri: Url {
-                                scheme: "file",
-                                cannot_be_a_base: false,
-                                username: "",
-                                password: None,
-                                host: None,
-                                port: None,
-                                path: "/foo/bar.zeek",
-                                query: None,
-                                fragment: None,
-                            },
-                        },
-                    ),
-                    documentation: "A new field.\n* * *\n```zeek\n# In bar::Y\ny2: count &optional;\n```",
-                },
-            ],
+        id: "zeek_init",
+        fqid: "bar::zeek_init",
+        kind: EventDef(
+            Signature {
+                result: None,
+                args: [],
+            },
         ),
         is_export: Some(
             false,
@@ -311,22 +312,22 @@ expression: root_decls
             Location {
                 range: Range {
                     start: Position {
-                        line: 22,
+                        line: 15,
                         character: 14,
                     },
                     end: Position {
-                        line: 25,
-                        character: 16,
+                        line: 17,
+                        character: 15,
                     },
                 },
                 selection_range: Range {
                     start: Position {
-                        line: 22,
-                        character: 27,
+                        line: 15,
+                        character: 20,
                     },
                     end: Position {
-                        line: 22,
-                        character: 28,
+                        line: 15,
+                        character: 29,
                     },
                 },
                 uri: Url {
@@ -342,54 +343,7 @@ expression: root_decls
                 },
             },
         ),
-        documentation: "```zeek\nredef record Y += {\n                  ## A new field.\n                  y2: count &optional;\n              };\n```",
-    },
-    Decl {
-        module: String(
-            "test",
-        ),
-        id: "y",
-        fqid: "test::y",
-        kind: Global,
-        is_export: Some(
-            true,
-        ),
-        loc: Some(
-            Location {
-                range: Range {
-                    start: Position {
-                        line: 4,
-                        character: 18,
-                    },
-                    end: Position {
-                        line: 4,
-                        character: 31,
-                    },
-                },
-                selection_range: Range {
-                    start: Position {
-                        line: 4,
-                        character: 25,
-                    },
-                    end: Position {
-                        line: 4,
-                        character: 26,
-                    },
-                },
-                uri: Url {
-                    scheme: "file",
-                    cannot_be_a_base: false,
-                    username: "",
-                    password: None,
-                    host: None,
-                    port: None,
-                    path: "/foo/bar.zeek",
-                    query: None,
-                    fragment: None,
-                },
-            },
-        ),
-        documentation: "```zeek\nglobal y = 1;\n```",
+        documentation: "```zeek\nevent zeek_init() { local x=1;\n                  # Comment.\n              }\n```",
     },
     Decl {
         module: String(
@@ -482,7 +436,7 @@ expression: root_decls
                 },
             },
         ),
-        documentation: "Y does the y. It takes no arguments. But it also has a field y\n* * *\n```zeek\ntype Y: record {\n                  ## A field.\n                  y: vector of count &optional;\n              };\n```",
+        documentation: "Y does the y.\nIt takes no arguments.\nBut it also has a field y\n* * *\n```zeek\ntype Y: record {\n                  ## A field.\n                  y: vector of count &optional;\n              };\n```",
     },
     Decl {
         module: String(
@@ -531,4 +485,51 @@ expression: root_decls
         ),
         documentation: "```zeek\nconst x = 1 &redef;\n```",
     },
-}
+    Decl {
+        module: String(
+            "test",
+        ),
+        id: "y",
+        fqid: "test::y",
+        kind: Global,
+        is_export: Some(
+            true,
+        ),
+        loc: Some(
+            Location {
+                range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 18,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 31,
+                    },
+                },
+                selection_range: Range {
+                    start: Position {
+                        line: 4,
+                        character: 25,
+                    },
+                    end: Position {
+                        line: 4,
+                        character: 26,
+                    },
+                },
+                uri: Url {
+                    scheme: "file",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: None,
+                    port: None,
+                    path: "/foo/bar.zeek",
+                    query: None,
+                    fragment: None,
+                },
+            },
+        ),
+        documentation: "```zeek\nglobal y = 1;\n```",
+    },
+]

--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeek-language-server",
-  "version": "0.64.4",
+  "version": "0.64.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeek-language-server",
-      "version": "0.64.4",
+      "version": "0.64.5",
       "license": "MIT",
       "dependencies": {
         "tar": "^7.4.3",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zeek",
   "description": "Zeek language support for Visual Studio Code",
   "author": "Benjamin Bannier",
-  "version": "0.64.4",
+  "version": "0.64.5",
   "license": "MIT",
   "publisher": "bbannier",
   "preview": false,


### PR DESCRIPTION
Zeekygen comments might contain e.g., hardformatted tables and we want
to preserve their formatting.