### PR TITLE
Ignore lint for foreign type as key

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,0 +1,1 @@
+ignore-interior-mutability = ["tower_lsp_server::lsp_types::Uri"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,4 +82,3 @@ missing_errors_doc = "allow"
 ignored_unit_patterns = "deny"
 clone_on_ref_ptr = "deny"
 redundant_clone = "deny"
-mutable_key_type = "allow" # TODO(bbannier): We should probably enable this.


### PR DESCRIPTION
We do not mutate this type.